### PR TITLE
Updates to tfa_basic to get GoogleAuth working with TFA module.

### DIFF
--- a/src/Plugin/TfaValidation/TfaBasicHelpValidation.php
+++ b/src/Plugin/TfaValidation/TfaBasicHelpValidation.php
@@ -12,7 +12,7 @@ use Drupal\Core\Form\FormStateInterface;
 
 /**
  * @TfaValidation(
- *   id = "tfa_basic_help_validation",
+ *   id = "tfa_basic_help",
  *   label = @Translation("TFA Basic Help"),
  *   description = @Translation("TFA Basic Help Plugin")
  * )

--- a/src/Plugin/TfaValidation/TfaBasicRecoveryCode.php
+++ b/src/Plugin/TfaValidation/TfaBasicRecoveryCode.php
@@ -13,7 +13,7 @@ use Drupal\Core\Form\FormStateInterface;
 
 /**
  * @TfaValidation(
- *   id = "tfa_basic_recovery_code_validation",
+ *   id = "tfa_basic_recovery_code",
  *   label = @Translation("TFA Recovery Code Validation"),
  *   description = @Translation("TFA Recovery Code Validation Plugin")
  * )

--- a/src/Plugin/TfaValidation/TfaBasicSms.php
+++ b/src/Plugin/TfaValidation/TfaBasicSms.php
@@ -7,7 +7,7 @@ use Drupal\Core\Form\FormStateInterface;
 
 /**
  * @TfaValidation(
- *   id = "tfa_basic_sms_validation",
+ *   id = "tfa_basic_sms",
  *   label = @Translation("TFA SMS Validation"),
  *   description = @Translation("TFA SMS Validation Plugin")
  * )

--- a/src/Plugin/TfaValidation/TfaTrustedBrowser.php
+++ b/src/Plugin/TfaValidation/TfaTrustedBrowser.php
@@ -13,7 +13,7 @@ use Drupal\tfa\Plugin\TfaSetupInterface;
 
 /**
  * @TfaValidation(
- *   id = "tfa_basic_help_validation",
+ *   id = "tfa_basic_help",
  *   label = @Translation("TFA Basic Help"),
  *   description = @Translation("TFA Basic Help Plugin")
  * )

--- a/src/googleauthenticator/GoogleAuthenticator.php
+++ b/src/googleauthenticator/GoogleAuthenticator.php
@@ -2,6 +2,8 @@
 
 /**
  * PHP Class for handling Google Authenticator 2-factor authentication
+ * @file class for GoogleAuthenticator
+ *
  *
  * @author Michael Kliewe
  * @copyright 2012 Michael Kliewe
@@ -9,9 +11,9 @@
  * @link http://www.phpgangsta.de/
  */
 
-namespace Drupal\tfa_basic\googleauthenticator;
+namespace Drupal\tfa_basic\GoogleAuthenticator;
 
-class PHPGangsta_GoogleAuthenticator
+class GoogleAuthenticator
 {
     protected $_codeLength = 6;
 


### PR DESCRIPTION
- Refactored code as needed to get TfaTotp working. 
- Removed the _<plugin_type> from the plugin id's so they match the plugins defined in the hook_tfa_api() definition. Makes sense that each plugin type will have setup + validation defined for it.
- Refactored GoogleAuthenticator file structure to match PSR-4 for autoloading requirements.
