### PR TITLE
Add GoogleAuthenticator as a composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "drupal/tfa_basic",
+    "description": "Basic Authentication Plugin for TFA Module",
+    "license": "GPL-2.0+",
+    "minimum-stability": "dev",
+    "require": {
+        "phpgangsta/googleauthenticator": "dev-master"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "drupal/tfa_basic",
+    "type": "drupal-module",
     "description": "Basic Authentication Plugin for TFA Module",
     "license": "GPL-2.0+",
     "minimum-stability": "dev",

--- a/src/Plugin/TfaValidation/TfaTotp.php
+++ b/src/Plugin/TfaValidation/TfaTotp.php
@@ -9,13 +9,12 @@ namespace Drupal\tfa_basic\Plugin\TfaValidation;
 use Drupal\tfa\Plugin\TfaBasePlugin;
 use Drupal\tfa\Plugin\TfaValidationInterface;
 use Drupal\tfa\Plugin\TfaSetupInterface;
-use Drupal\tfa_basic\GoogleAuthenticator\GoogleAuthenticator;
 use Drupal\Core\Url;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\user\Entity\User;
 use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Site\Settings;
-
+use PHPGangsta_GoogleAuthenticator as GoogleAuthenticator;
 
 /**
  * @TfaValidation(


### PR DESCRIPTION
As referenced in this https://github.com/d8-contrib-modules/tfa_basic/issues/2
Modules should use composer for dependencies.
